### PR TITLE
fix(ci): run go mod tidy before test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: tidy go mod
+        run: go mod tidy
       - name: test
         run: go run gotest.tools/gotestsum@latest --format github-actions
       - name: lint


### PR DESCRIPTION
Run `go mod tidy` before run tests in the ci pipelinme.